### PR TITLE
built 404.html to root

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -10,7 +10,7 @@ const site = lume({
   // emptyDest: false,
   server: {
     open: true,
-    page404: "./custom404/index.html",
+    page404: "./404.html",
   },
   location: new URL("https://sitblueprint.com"),
   watcher: {

--- a/src/404.md
+++ b/src/404.md
@@ -1,6 +1,7 @@
 ---
 title: Stevens Blueprint
 layout: _layouts/Placeholder.jsx
+url: ./404.html
 headline: 404 Error!
 description: Unfortunately, the page you are trying to access does not exist.
 ---

--- a/src/_includes/_layouts/Placeholder.jsx
+++ b/src/_includes/_layouts/Placeholder.jsx
@@ -1,4 +1,4 @@
-export default ({ headline, description }) => {
+export default ({ comp, headline, description }) => {
   const logo = "../assets/logos/logo.png";
   return (
     <html>
@@ -7,7 +7,8 @@ export default ({ headline, description }) => {
         <title>Stevens Blueprint</title>
       </head>
       <body>
-        <div className="flex lg:flex-row flex-col justify-center items-center h-screen w-screen p-2">
+        <comp.Navbar />
+        <div className="flex absolute top-0 left-0 lg:flex-row flex-col justify-center items-center h-screen w-screen p-2">
           <div className="flex flex-col pr-2">
             <h1 className="text-4xl font-bold">blueprint</h1>
             <div className="text-xl">


### PR DESCRIPTION

![image](https://github.com/stevensblueprint/blueprint_website/assets/94158310/8377028b-b6d2-4ec9-ac98-2f63364010cf)


Adjusted build path for the 404.html file to build to the root directory of the output folder. Before it was building into custom404/index.html, so I believe GitHub pages wasn't able to recognize it.