### PR TITLE
Feature/our sponsors - made layout to match figma design

### DIFF
--- a/src/_includes/_layouts/Home.jsx
+++ b/src/_includes/_layouts/Home.jsx
@@ -121,19 +121,27 @@ export default ({ comp, title }) => {
             redirect_url={"projects"}
           />
         </section>
-        <section className="h-[17rem] bg-primary text-negative flex flex-col justify-evenly items-center justify-center py-16 max-lg:h-fit max-lg:gap-y-16 max-lg:py-16">
-          <h1 className="lg:text-5xl text-6xl mb-12">
-            <strong>Sponsors and Partners</strong>
+        {/* TODO: address div separation */}
+        <section
+          className="h-[17rem] bg-negative text-negative flex flex-col justify-evenly  py-16 max-lg:h-fit max-lg:gap-y-16 max-lg:py-16"
+          id="sponsors"
+        >
+          <h1 className="lg:text-5xl text-6xl mt-10 mb-2 ml-5 text-black text-left">
+            <strong>Our Sponsors</strong>
           </h1>
-          <div className="flex flex-wrap gap-x-6 justify-center px-8 max-lg:px-4 max-md:px-2">
+          <p className="text-black text-left text-2xl ml-5 mb-10">
+            We are grateful to our sponsors who provide us with the resources
+            and support we need at Blueprint!
+          </p>
+          <div className="flex flex-wrap gap-x-6 justify-center px-8 max-lg:px-4 max-md:px-2 mb-10">
             <img
               className="object-contain h-20 max-w-none mr-4"
-              src="../assets/logos/github.png"
+              src="../assets/logos/notion.png"
               alt="GitHub logo"
             />
             <img
               className="object-contain h-20 max-w-none mr-4"
-              src="../assets/logos/notion.png"
+              src="../assets/logos/github.png"
               alt="Notion logo"
             />
           </div>

--- a/src/_includes/_layouts/Home.jsx
+++ b/src/_includes/_layouts/Home.jsx
@@ -121,19 +121,18 @@ export default ({ comp, title }) => {
             redirect_url={"projects"}
           />
         </section>
-        {/* TODO: address div separation */}
         <section
-          className="h-[17rem] bg-negative text-negative flex flex-col justify-evenly  py-16 max-lg:h-fit max-lg:gap-y-16 max-lg:py-16"
+          className="bg-negative text-negative flex flex-col justify-evenly  py-16 max-lg:h-fit max-lg:gap-y-6 max-lg:py-16"
           id="sponsors"
         >
           <h1 className="lg:text-5xl text-6xl mt-10 mb-2 ml-5 text-black text-left">
             <strong>Our Sponsors</strong>
           </h1>
-          <p className="text-black text-left text-2xl ml-5 mb-10">
+          <p className="text-black text-left text-3xl lg:text-[1.7rem] ml-5 mb-10 max-lg:mb-8">
             We are grateful to our sponsors who provide us with the resources
             and support we need at Blueprint!
           </p>
-          <div className="flex flex-wrap gap-x-6 justify-center px-8 max-lg:px-4 max-md:px-2 mb-10">
+          <div className="flex flex-wrap gap-x-6 justify-center px-8 max-lg:px-4 max-md:px-2 mb-10 max-lg:-mt-4">
             <img
               className="object-contain h-20 max-w-none mr-4"
               src="../assets/logos/notion.png"


### PR DESCRIPTION
Closes #164 

# Reference

<img width="563" alt="image" src="https://github.com/user-attachments/assets/583798bf-e193-4a9e-ab4e-d6cec60a1779">

[Figma Mockup](https://www.figma.com/design/Zw1lNlwMEahJCcN5X2L0WT/Blueprint-Website-Redesign-2024?node-id=1-2&t=FjeUrUIztUhqmBA5-0)

# Desktop View
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/265fdb97-1bc3-4621-9a0a-9aee28beeeb1">

# Mobile View
![image](https://github.com/user-attachments/assets/e9dd3eb7-638d-482e-a159-87f966d81d63)
