### PR TITLE
hotfix: changed deno version in deploy build stage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Deno environment
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Build site
         run: deno task build


### PR DESCRIPTION
## Description
The deployment to gh pages failed due to a mismatch with the deno version in `deno.json`. I changed the deno version in the `deploy.yml` workflow