### PR TITLE
refactored into component and fixed headign text

### DIFF
--- a/src/_components/Home/Impact.jsx
+++ b/src/_components/Home/Impact.jsx
@@ -1,0 +1,34 @@
+import React from "https://esm.sh/react";
+
+export default function Impact() {
+  return (
+    <section className="flex flex-col items-center justify-center py-32 gap-y-6 bg-gray-50">
+      <h1 className="lg:text-5xl text-7xl text-center lg:pb-20 sm:pb-10">
+        <strong>Our Impact</strong>
+      </h1>
+      <div className="flex lg:flex-row sm:flex-col gap-20 items-center justify-evenly">
+        <div className="flex flex-col items-center justify-center">
+          <h2 className="text-9xl text-secondary font-bold">4</h2>
+          <span className="text-center text-3xl font-bold">
+            <span className="block">NON-PROFIT</span>
+            <span className="block">PROJECTS</span>
+          </span>
+        </div>
+        <div className="flex flex-col items-center justify-center">
+          <h2 className="text-9xl text-primary font-bold">5,000</h2>
+          <span className="text-center text-3xl font-bold">
+            <span className="block">ACCUMULATED</span>
+            <span className="block">VOLUNTEER HOURS</span>
+          </span>
+        </div>
+        <div className="flex flex-col items-center justify-center">
+          <h2 className="text-9xl text-secondary font-bold">80</h2>
+          <span className="text-center text-3xl font-bold">
+            <span className="block">STUDENT</span>
+            <span className="block">VOLUNTEERS</span>
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/_includes/_layouts/Home.jsx
+++ b/src/_includes/_layouts/Home.jsx
@@ -16,34 +16,7 @@ export default ({ comp, title }) => {
       <body>
         <comp.Navbar />
         <comp.Home.Hero />
-        <section className="flex flex-col items-center justify-center py-32 gap-y-6 bg-gray-50">
-          <h1 className="lg:text-5xl text-7xl">
-            <strong>About Us</strong>
-          </h1>
-          <div className="flex lg:flex-row sm:flex-col gap-20 items-center justify-evenly">
-            <div className="flex flex-col items-center justify-center">
-              <h2 className="text-9xl text-secondary font-bold">4</h2>
-              <span className="text-center text-3xl font-bold">
-                <span className="block">NON-PROFIT</span>
-                <span className="block">PROJECTS</span>
-              </span>
-            </div>
-            <div className="flex flex-col items-center justify-center">
-              <h2 className="text-9xl text-primary font-bold">5,000</h2>
-              <span className="text-center text-3xl font-bold">
-                <span className="block">ACCUMULATED</span>
-                <span className="block">VOLUNTEER HOURS</span>
-              </span>
-            </div>
-            <div className="flex flex-col items-center justify-center">
-              <h2 className="text-9xl text-secondary font-bold">80</h2>
-              <span className="text-center text-3xl font-bold">
-                <span className="block">STUDENT</span>
-                <span className="block">VOLUNTEERS</span>
-              </span>
-            </div>
-          </div>
-        </section>
+        <comp.Home.Impact />
         <section className="flex flex-col items-center justify-center py-32 gap-y-6 bg-white">
           <h1 className="lg:text-5xl text-7xl">
             <strong>What We Do</strong>


### PR DESCRIPTION
# Description

I made a mistake in my last PR for the home-hero and accidentally replaced 'Our Impact' with 'About Us'. This PR fixes that and also refactors the Our Impact into the Hero components folder.

Old:
![image](https://github.com/user-attachments/assets/e8594a64-4b15-48c0-9588-91216a974dd4)

New:
![image](https://github.com/user-attachments/assets/5dfeb27f-d03d-4bac-823a-74c0baf3c1a4)
