### PR TITLE
Fix/values not aligned

### DIFF
--- a/src/_includes/_layouts/About.jsx
+++ b/src/_includes/_layouts/About.jsx
@@ -36,7 +36,7 @@ export default ({ comp, values, team }) => (
         />
         <section className="flex place-content-center" id="info">
           <div className="flex flex-col items-center py-20 max-lg:px-12max-md:px-4">
-            <h1 className="leading-10 justify-center md:text-[40px] mb-14 text-6xl">
+            <h1 className="leading-10 md:text-[40px] mb-14 text-6xl">
               <strong>Our Values</strong>
             </h1>
             <div className="flex flex-col sm:flex-row p-20 gap-10">

--- a/src/_includes/_layouts/About.jsx
+++ b/src/_includes/_layouts/About.jsx
@@ -36,10 +36,10 @@ export default ({ comp, values, team }) => (
         />
         <section className="flex place-content-center" id="info">
           <div className="flex flex-col items-center py-20 max-lg:px-12max-md:px-4">
-            <h1 className="leading-10 md:text-[40px] mb-14 text-6xl">
+            <h1 className="leading-10 justify-center md:text-[40px] mb-14 text-6xl">
               <strong>Our Values</strong>
             </h1>
-            <div className="flex flex-row items-center p-20 gap-10">
+            <div className="flex flex-col sm:flex-row p-20 gap-10">
               {values.map((value, index) => (
                 <comp.ValueCard key={index} value={value} />
               ))}


### PR DESCRIPTION
Issue [#279]

Fixed the text so it stays even no matter the size of the screen
Now on small screens, the values are in rows instead of columns

Previous: 
![image](https://github.com/user-attachments/assets/b03c8562-d039-45f7-b86d-553bc6c42deb)

Now:
<img width="933" alt="image" src="https://github.com/user-attachments/assets/0f04e832-a71a-4727-929d-88ff8d2efd5a" />
<img width="334" alt="image" src="https://github.com/user-attachments/assets/ebbfb95d-a654-4a32-8f8f-66665a01dbc0" />
