### PR TITLE
fix/home-page

### DIFF
--- a/src/_components/GetInvolvedCard.jsx
+++ b/src/_components/GetInvolvedCard.jsx
@@ -7,7 +7,7 @@ export default function GetInvolvedCard({
   redirect_url,
 }) {
   return (
-    <figure className="flex flex-col w-full border border-black rounded-lg lg:p-5 p-8 lg:max-w-[445px] h-[450px]">
+    <figure className="flex flex-col w-full max-w-[350px] border border-black rounded-lg p-4 md:p-6 min-h-[400px]">
       <div className="h-36 flex justify-center items-center w-full shrink-0">
         <img
           src={icon_url}

--- a/src/_components/ProjectCard.jsx
+++ b/src/_components/ProjectCard.jsx
@@ -10,7 +10,7 @@ export default function ProjectCard({
 }) {
   const box_styling = status === "Completed" ? "bg-primary" : "bg-maroon";
   return (
-    <figure className="flex-col flex w-full border border-black rounded-lg lg:p-10 p-8 lg:max-w-[600px]">
+    <figure className="flex-col flex w-[350px] border border-black rounded-lg lg:p-6 p-8">
       <div className="flex flex-row justify-start items-center w-full">
         <p
           className={`${box_styling} px-2 py-1 max-w-max my-3 rounded-md text-white lg:text-md text-md font-medium`}

--- a/src/_includes/_layouts/Home.jsx
+++ b/src/_includes/_layouts/Home.jsx
@@ -30,7 +30,7 @@ export default ({ comp, title, about }) => {
           <p className="text-center-2xl lg:text-2xl text-2xl text-primary hover:underline">
             <a href="projects">View all projects</a>
           </p>
-          <div className="flex flex-row justify-between gap-x-6 lg:gap-x-12 lg:flex-wrap lg:gap-y-6">
+          <div className="flex flex-col md:flex-row justify-center items-center gap-6 w-full">
             <comp.ProjectCard
               name_organization={"Sarapis"}
               image_url={"../assets/logos/sarapis_logo.png"}
@@ -67,7 +67,7 @@ export default ({ comp, title, about }) => {
           <h1 className="lg:text-5xl text-7xl">
             <strong>Get Involved</strong>
           </h1>
-          <div className="flex flex-row justify-between gap-x-6 lg:gap-x-12 lg:flex-wrap lg:gap-y-6">
+          <div className="flex flex-col md:flex-row justify-center items-center gap-6 w-full">
             <comp.GetInvolvedCard
               title={"Non-Profit Orgs"}
               description={


### PR DESCRIPTION
Reduced the size of projects-cards and get-involved-cards, as well as their responsiveness

Result:

<img width="1440" alt="Screenshot 2025-01-29 at 3 40 05 PM" src="https://github.com/user-attachments/assets/1dd8c79c-a9ce-44a6-a06d-112ccb4c686d" />

Mobile:

<img width="1440" alt="Screenshot 2025-01-29 at 3 40 35 PM" src="https://github.com/user-attachments/assets/2c5aa6bf-17cc-4e5c-b845-21f10dd01e3f" />
