### PR TITLE
NPOs page responsiveness

### DIFF
--- a/src/_components/DropdownFAQ.jsx
+++ b/src/_components/DropdownFAQ.jsx
@@ -20,7 +20,7 @@ export default function DropdownFAQ({ faq, index }) {
           className="h-[7px] w-3 peer-checked:group-[]:rotate-180"
         />
       </label>
-      <div className="overflow-hidden max-h-0 peer-checked:max-h-max w-full transition-all duration-300 px-3 peer-checked:pt-2 peer-checked:pb-[20px]">
+      <div className="overflow-hidden max-h-0 peer-checked:max-h-96 w-full transition-all duration-300 px-3 peer-checked:pt-2 peer-checked:pb-[20px]">
         <div className="prose prose-p:text-xl prose-p:leading-6 max-w-none">
           <ReactMarkdown>{faq.answer}</ReactMarkdown>
         </div>

--- a/src/_components/ForNPOs/ContactUs.jsx
+++ b/src/_components/ForNPOs/ContactUs.jsx
@@ -3,10 +3,10 @@ import React from "react";
 export default function ContactUs({ comp }) {
   return (
     <section>
-      <div className="flex justify-center pt-12 md:pt-20">
-        <p className="text-center text-4xl font-semibold max-w-3xl text-primary">
-          Want to get in touch with us? Reach out at
-          <a href="mailto:sit.blueprint@gmail.com" className="block">
+      <div className="flex justify-center pt-12 md:pt-8 px-8 lg:px-40">
+        <p className="text-3xl lg:text-4xl text-center text-primary font-bold px-8 lg:px-0 lg:w-3/5 my-12">
+          Want to get in touch with us? Reach out at{" "}
+          <a href="mailto:sit.blueprint@gmail.com" className="inline-block">
             sit.blueprint@gmail.com
             <img
               className="object-cover inline h-8 w-8 ml-2"
@@ -16,10 +16,10 @@ export default function ContactUs({ comp }) {
           </a>
         </p>
       </div>
-      <div className="flex justify-center pt-12">
+      <div className="flex justify-center pb-32">
         <comp.Button
           style={
-            "block lg:px-8 px-8 lg:py-2 py-2 lg:rounded-md rounded-md border border-black text-base leading-normal font-bold w-fit lg:text-base text-4xl"
+            "block px-8 py-2 lg:rounded-md rounded-md border border-black text-base leading-normal font-bold w-fit lg:text-base text-4xl"
           }
           text={"Download our proposal template"}
           redirect_url={"../../assets/docs/NPO_Project_Proposal.pdf"}

--- a/src/_components/ForNPOs/Hero.jsx
+++ b/src/_components/ForNPOs/Hero.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Hero({ comp }) {
   return (
-    <section className="grow flex space-between flex-col min-h-[700px] lg:flex-row lg:items-center relative overflow-hidden bg-primary text-white px-12 lg:px-40 ">
+    <section className="grow flex space-between flex-col min-h-[700px] lg:flex-row lg:items-center relative overflow-hidden bg-primary text-white px-6 md:px-12 lg:px-32">
       <div className="py-8 md:py-16 lg:py-0 w-full lg:pr-16">
         <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16 text-center lg:text-left">
           Non-Profit Organizations

--- a/src/_components/ForNPOs/Hero.jsx
+++ b/src/_components/ForNPOs/Hero.jsx
@@ -4,14 +4,14 @@ export default function Hero({ comp }) {
   return (
     <section className="grow flex space-between flex-col min-h-[700px] lg:flex-row lg:items-center relative overflow-hidden bg-primary text-white px-6 md:px-12 lg:px-32">
       <div className="py-8 md:py-16 lg:py-0 w-full lg:pr-16">
-        <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16 text-center lg:text-left">
+        <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16">
           Non-Profit Organizations
         </h1>
-        <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14 text-center lg:text-left">
+        <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14">
           We are passionate about leveraging our technical and consulting skills
           to support your organization’s mission, free of charge!
         </p>
-        <div className="flex flex-col md:flex-row md:justify-center lg:justify-start space-y-4 md:space-y-0 md:space-x-6">
+        <div className="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-6">
           <comp.HeroButton
             text="Email Us"
             redirect_url="mailto:sit.blueprint@gmail.com"

--- a/src/_components/ForNPOs/ProjectCriteria.jsx
+++ b/src/_components/ForNPOs/ProjectCriteria.jsx
@@ -2,8 +2,11 @@ import React from "react";
 
 export default function ProjectCriteria({ projectCriteria, testimonial }) {
   return (
-    <figure className="flex-col flex w-full px-12 py-8 lg:py-16 lg:px-40">
-      <h1 className="text-4xl font-bold pb-6"> What We're Looking For </h1>
+    <figure className="flex-col flex w-full py-8 lg:py-16 px-8 lg:px-40">
+      <h1 className="text-3xl lg:text-4xl font-bold pb-6">
+        {" "}
+        What We're Looking For{" "}
+      </h1>
       <div className="flex flex-col lg:flex-row">
         {/* Left Side Content */}
         <div className="flex flex-col w-full lg:w-1/2">
@@ -17,7 +20,7 @@ export default function ProjectCriteria({ projectCriteria, testimonial }) {
                     alt={criteria.title}
                   />
                 </div>
-                <div className="font-semibold text-3xl text-primary">
+                <div className="font-semibold text-2xl lg:text-3xl text-primary">
                   <p>{criteria.title}</p>
                 </div>
               </div>
@@ -30,25 +33,16 @@ export default function ProjectCriteria({ projectCriteria, testimonial }) {
           ))}
         </div>
         {/* Right Side Content */}
-        <div className="flex hidden md:block sm:pt-8 sm:pb-24 md:w-1/2">
-          <div className="pt-12 sm:pt-0 sm:pl-24 w-3/4 h-60 self-center">
-            <div className="z-00 relative bg-primary rounded-2xl md:min-w-[400px]">
+        <div className="flex block sm:pt-8 pb-24 lg:pb-24 lg:w-1/2">
+          <div className="pt-12 sm:pt-0 sm:pl-24 w-[calc(100%-48px)] sm:w-3/4 min-h-60 self-center">
+            <div className="relative bg-primary rounded-2xl md:min-w-[400px]">
               <p className="text-white py-7 px-8 italic">{testimonial.text}</p>
-              <div className="-z-10 absolute sm:left-12 sm:-bottom-12 sm:w-11/12 h-full sm:w-full md:min-w-[350px] bg-sky-100 rounded-2xl">
-                <p className="absolute sm:bottom-4 sm:left-6 font-bold">
+              <div className="-z-10 absolute left-12 sm:-bottom-14 -bottom-20 h-full w-full md:min-w-[350px] bg-sky-100 rounded-2xl">
+                <p className="absolute bottom-4 left-6 font-bold p-1">
                   - {testimonial.npo}
                 </p>
               </div>
             </div>
-          </div>
-        </div>
-        {/* Testimonial on small screen sizes - removes absolute overlap */}
-        <div className="md:hidden pt-4">
-          <div className="bg-primary rounded-2xl text-white p-8 italic">
-            {testimonial.text}
-          </div>
-          <div className="bg-sky-100 rounded-2xl p-4 font-bold">
-            - {testimonial.npo}
           </div>
         </div>
       </div>

--- a/src/_components/ForNPOs/ProjectTimeline.jsx
+++ b/src/_components/ForNPOs/ProjectTimeline.jsx
@@ -4,16 +4,18 @@ export default function ProjectTimeline({ projectTimeline }) {
   return (
     <section
       id="project-timeline"
-      className="grow bg-neg text-black px-12 lg:px-40 pt-16 lg:pt-24 pb-8"
+      className="grow bg-neg text-black px-8 lg:px-40 pt-16 lg:pt-24 pb-8"
     >
       <div className="">
-        <h1 className="text-4xl font-bold pb-8">Our Project Timeline</h1>
+        <h1 className="text-3xl lg:text-4xl font-bold pb-4 lg:pb-8">
+          Our Project Timeline
+        </h1>
       </div>
       <div className="grid lg:grid-cols-3">
         {projectTimeline.map((phase, index) => {
           return (
             <div key={index} className="py-8 lg:pr-12">
-              <h2 className="pb-4 text-3xl text-primary font-bold">
+              <h2 className="pb-4 text-2xl lg:text-3xl text-primary font-bold">
                 {phase.title}
               </h2>
               <p className="text-xl">{phase.description}</p>

--- a/src/_components/ForStudents/InternalTeams.jsx
+++ b/src/_components/ForStudents/InternalTeams.jsx
@@ -44,7 +44,7 @@ export default function InternalTeams() {
       <div className="flex flex-col items-center p-12 max-lg:px-12 max-md:w-full max-md:px-4">
         <h1 className="text-3xl lg:text-4xl text-center text-primary font-bold px-8 lg:px-0 lg:w-3/5 my-12 lg:my-16">
           Have any questions? Reach out at{" "}
-          <a href="mailto:sit.blueprint@gmail.com" className="block">
+          <a href="mailto:sit.blueprint@gmail.com" className="inline-block">
             sit.blueprint@gmail.com
             <img
               className="object-cover inline h-8 w-8 ml-2"

--- a/src/_includes/_layouts/ForNPOs.jsx
+++ b/src/_includes/_layouts/ForNPOs.jsx
@@ -7,8 +7,12 @@ export default ({
 }) => (
   <html>
     <head>
+      <comp.OpenGraphCommon />
       <link rel="stylesheet" href="/styles.css" />
-      <title> For Non-Profits </title>
+      <title>For Non-Profits</title>
+      <meta property="og:title" content="Non-Profits" />
+      <meta property="og:url" content="https://sitblueprint.com/non-profits/" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
     <body>
       <>
@@ -20,7 +24,7 @@ export default ({
           testimonial={testimonial}
         />
         <comp.ForNPOs.ContactUs />
-        <section className="flex flex-col justify-center mb-16 px-12 lg:px-40">
+        <section className="flex flex-col justify-center mb-16 px-8 lg:px-40">
           <h1 className="text-4xl font-bold py-3">FAQs</h1>
           <div className="w-full flex flex-col">
             {faqs.map((faq, index) => (

--- a/src/_includes/_layouts/ForStudents.jsx
+++ b/src/_includes/_layouts/ForStudents.jsx
@@ -5,10 +5,7 @@ export default ({ comp, faqs, timelineContent }) => (
       <link rel="stylesheet" href="/styles.css" />
       <title>Students</title>
       <meta property="og:title" content="Students" />
-      <meta
-        property="og:url"
-        content="https://sitblueprint.com/community/students/"
-      />
+      <meta property="og:url" content="https://sitblueprint.com/students/" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
     <body>


### PR DESCRIPTION
# Description

This is part 2 of a mobile responsiveness PR for Community pages. This PR includes the changes for the NPOs page. What was done:
- fixed consistency of padding on the page
- ensured text sizes for different heading levels were consistent for the mobile view too

Note: #277 may have messed up the mobile page hero so I will probably make a PR to make all of the hero's buttons also mobile friendly because as of rn all the buttons are very tiny when viewed on mobile

# Demo

<img src="https://github.com/user-attachments/assets/aa8109d8-8a78-49b5-a451-13d90fe04256" alt="drawing" width="300"/>

---

Related to #265 
