### PR TITLE
Bug/contact us width

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -41,6 +41,7 @@
     "npm:postcss-import@16.1.0": "16.1.0_postcss@8.4.49",
     "npm:postcss@8.4.49": "8.4.49",
     "npm:prettier-plugin-tailwindcss@~0.6.8": "0.6.10_prettier@3.4.2",
+    "npm:prettier@3.4.2": "3.4.2",
     "npm:prettier@^3.2.5": "3.4.2",
     "npm:react-dom@18.3.1": "18.3.1_react@18.3.1",
     "npm:react@*": "18.3.1",

--- a/src/_components/Home/ContactUs.jsx
+++ b/src/_components/Home/ContactUs.jsx
@@ -1,8 +1,10 @@
 export default ({ comp, title }) => {
   return (
-    <section className="text-black flex lg:flex-row flex-col justify-between items-center gap-y-16 py-16 lg:px-48">
-      <div className="lg:w-1/2 shrink-0">
-        <h3 className="lg:text-5xl text-5xl text-center lg:text-left mb-4 font-bold">Contact Us</h3>
+    <section className="text-black flex lg:flex-row flex-col justify-between items-center gap-y-8 py-16 lg:px-48">
+      <div className="w-full lg:w-1/2 shrink-0 max-sm:px-4">
+        <h3 className="lg:text-5xl text-5xl text-center lg:text-left mb-4 font-bold">
+          Contact Us
+        </h3>
         <p className="lg:text-2xl text-4xl text-center lg:text-left">
           Feel free to reach out to us via...
         </p>
@@ -10,17 +12,17 @@ export default ({ comp, title }) => {
       <div className="flex flex-col md:flex-row items-center gap-x-6 gap-y-2">
         <comp.Button
           text="Email"
-          style="px-16 min-w-[275px] md:min-w-[0px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
+          style="px-16 max-md:min-w-[275px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
           redirect_url="mailto:sit.blueprint@gmail.com"
         />
         <comp.Button
           text="LinkedIn"
-          style="px-16 min-w-[275px] md:min-w-[0px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
+          style="px-16 max-md:min-w-[275px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
           redirect_url="https://www.linkedin.com/company/stevens-blueprint/"
         />
         <comp.Button
           text="Instagram"
-          style="px-16 min-w-[275px] md:min-w-[0px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
+          style="px-16 max-md:min-w-[275px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
           redirect_url="https://www.instagram.com/stevensblueprint/"
           openInNewTab
         />

--- a/src/_components/Home/ContactUs.jsx
+++ b/src/_components/Home/ContactUs.jsx
@@ -1,26 +1,26 @@
 export default ({ comp, title }) => {
   return (
     <section className="text-black flex lg:flex-row flex-col justify-between items-center gap-y-16 py-16 lg:px-48">
-      <div className="w-full">
+      <div className="lg:w-1/2 shrink-0">
         <h3 className="lg:text-5xl text-5xl text-center lg:text-left mb-4 font-bold">Contact Us</h3>
         <p className="lg:text-2xl text-4xl text-center lg:text-left">
           Feel free to reach out to us via...
         </p>
       </div>
-      <div className="flex flex-col md:flex-row items-center gap-6">
+      <div className="flex flex-col md:flex-row items-center gap-x-6 gap-y-2">
         <comp.Button
           text="Email"
-          style="px-16 py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] font-semibold text-lg inline-block max-lg:px-16 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
+          style="px-16 min-w-[275px] md:min-w-[0px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
           redirect_url="mailto:sit.blueprint@gmail.com"
         />
         <comp.Button
           text="LinkedIn"
-          style="px-16 py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] font-semibold text-lg inline-block max-lg:px-16 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
+          style="px-16 min-w-[275px] md:min-w-[0px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
           redirect_url="https://www.linkedin.com/company/stevens-blueprint/"
         />
         <comp.Button
           text="Instagram"
-          style="px-16 py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] font-semibold text-lg inline-block max-lg:px-16 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
+          style="px-16 min-w-[275px] md:min-w-[0px] py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] text-center font-semibold text-lg inline-block max-lg:px-16 lg:max-xl:px-7 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"
           redirect_url="https://www.instagram.com/stevensblueprint/"
           openInNewTab
         />

--- a/src/_components/Home/ContactUs.jsx
+++ b/src/_components/Home/ContactUs.jsx
@@ -1,13 +1,13 @@
 export default ({ comp, title }) => {
   return (
-    <section className="text-black flex lg:flex-row flex-col justify-between items-center py-16 lg:px-48">
+    <section className="text-black flex lg:flex-row flex-col justify-between items-center gap-y-16 py-16 lg:px-48">
       <div className="w-full">
-        <h3 className="lg:text-5xl text-5xl mb-4 font-bold">Contact Us</h3>
-        <p className="lg:text-2xl text-4xl">
+        <h3 className="lg:text-5xl text-5xl text-center lg:text-left mb-4 font-bold">Contact Us</h3>
+        <p className="lg:text-2xl text-4xl text-center lg:text-left">
           Feel free to reach out to us via...
         </p>
       </div>
-      <div className="flex flex-row items-center gap-6">
+      <div className="flex flex-col md:flex-row items-center gap-6">
         <comp.Button
           text="Email"
           style="px-16 py-2 rounded-lg bg-transparent border-[1px] border-[#00070E] text-[#00070E] font-semibold text-lg inline-block max-lg:px-16 max-lg:py-6 max-lg:text-3xl hover:bg-primary hover:text-white"


### PR DESCRIPTION
Issue https://github.com/stevensblueprint/blueprint_website/issues/249

- the buttons will be in a column rather than a row on small and medium screen sizes
- less padding for the buttons on lg to xl screen sizes to prevent overflowing text for "Feel free..."

With these changes:
![image](https://github.com/user-attachments/assets/bcd3a87e-be67-4863-a00a-6dace565c894)
<img width="930" alt="image" src="https://github.com/user-attachments/assets/15d2afe1-6b6e-480e-97d9-10b4f63821f7" />