### PR TITLE
added shadow to get involved and project cards

### DIFF
--- a/src/_components/GetInvolvedCard.jsx
+++ b/src/_components/GetInvolvedCard.jsx
@@ -7,7 +7,7 @@ export default function GetInvolvedCard({
   redirect_url,
 }) {
   return (
-    <figure className="flex flex-col shadow-lg hover:shadow-2xl md:w-1/3 border border-black rounded-lg lg:p-5 p-5 lg:h-[450px]">
+    <figure className="flex flex-col shadow-lg hover:shadow-2xl transition-shadow md:w-1/3 rounded-lg lg:p-5 p-5 lg:h-[450px]">
       <div className="h-36 flex justify-center items-center w-full shrink-0">
         <img
           src={icon_url}

--- a/src/_components/GetInvolvedCard.jsx
+++ b/src/_components/GetInvolvedCard.jsx
@@ -7,7 +7,7 @@ export default function GetInvolvedCard({
   redirect_url,
 }) {
   return (
-    <figure className="flex flex-col md:w-1/3 border border-black rounded-lg lg:p-5 p-5 lg:h-[450px]">
+    <figure className="flex flex-col shadow-lg hover:shadow-2xl md:w-1/3 border border-black rounded-lg lg:p-5 p-5 lg:h-[450px]">
       <div className="h-36 flex justify-center items-center w-full shrink-0">
         <img
           src={icon_url}

--- a/src/_components/ProjectCard.jsx
+++ b/src/_components/ProjectCard.jsx
@@ -10,7 +10,7 @@ export default function ProjectCard({
 }) {
   const box_styling = status === "Completed" ? "bg-primary" : "bg-maroon";
   return (
-    <figure className="flex-col flex shadow-lg hover:shadow-2xl w-full border border-black rounded-lg lg:p-10 p-8">
+    <figure className="flex-col flex shadow-lg hover:shadow-2xl transition-shadow w-full rounded-lg lg:p-10 p-8">
       <div className="flex flex-row justify-start items-center w-full">
         <p
           className={`${box_styling} px-2 py-1 max-w-max my-3 rounded-md text-white lg:text-lg text-lg font-medium`}

--- a/src/_components/ProjectCard.jsx
+++ b/src/_components/ProjectCard.jsx
@@ -10,7 +10,7 @@ export default function ProjectCard({
 }) {
   const box_styling = status === "Completed" ? "bg-primary" : "bg-maroon";
   return (
-    <figure className="flex-col flex w-full border border-black rounded-lg lg:p-10 p-8">
+    <figure className="flex-col flex shadow-lg hover:shadow-2xl w-full border border-black rounded-lg lg:p-10 p-8">
       <div className="flex flex-row justify-start items-center w-full">
         <p
           className={`${box_styling} px-2 py-1 max-w-max my-3 rounded-md text-white lg:text-lg text-lg font-medium`}


### PR DESCRIPTION
# Description

Related to issue #281 

Added shadow and thickened borders to help emphazie our "project" and "get involved" cards. In screenshots its a little difficult to tell, but the shadow effect on hover is very noticeable when actually running the website.

**Home Page:**

![image](https://github.com/user-attachments/assets/e8021e7a-021a-4de0-9766-d5c77600358b)

![image](https://github.com/user-attachments/assets/0a81e2a1-da60-40ae-94f6-c959bcff60a9)

**Project Page:**
![image](https://github.com/user-attachments/assets/0f7b0191-4b5b-49df-90a4-735402870fc2)
