### PR TITLE
About Page Mobile Responsiveness

### DIFF
--- a/src/_components/About/Hero.jsx
+++ b/src/_components/About/Hero.jsx
@@ -2,12 +2,12 @@ import React from "https://esm.sh/react";
 
 export default function Hero({ comp }) {
   return (
-    <section className="grow flex flex-col min-h-[700px] lg:flex-row lg:items-center overflow-hidden bg-primary text-white">
-      <div className="px-6 md:px-12 lg:pl-32 py-8 md:py-16 lg:py-0 w-full">
-        <h1 className="font-bold text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16 text-center lg:text-left">
+    <section className="grow flex flex-col min-h-[700px] lg:flex-row lg:items-center overflow-hidden bg-primary text-white px-6 md:px-12 lg:px-32">
+      <div className="py-8 md:py-16 lg:py-0 w-full lg:w-1/2 lg:pr-20">
+        <h1 className="font-bold text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16">
           About Us
         </h1>
-        <p className="text-[25px] md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14 text-left">
+        <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14 text-left">
           We are the Stevens Institute of Technology chapter of Blueprint that
           develops pro-bono software for non-profit organizations and promotes
           tech for social good.
@@ -21,11 +21,11 @@ export default function Hero({ comp }) {
           <comp.HeroButton text="See our projects" redirect_url="/projects" />
         </div>
       </div>
-      <div className="flex px-6 md:px-12 lg:32 grow w-full justify-center pb-12">
+      <div className="flex grow w-full lg:w-1/2 justify-center pb-8 md:pb-12">
         <image
           src="/assets/events/google_event_1_cropped.jpg"
           alt="A photo of Blueprint members at a Google Event in New York City"
-          className="rounded-[20px]"
+          className="rounded-2xl w-full h-auto object-cover"
         />
       </div>
     </section>

--- a/src/_components/About/Mission.jsx
+++ b/src/_components/About/Mission.jsx
@@ -1,15 +1,15 @@
 import React from "https://esm.sh/react";
 
-export default function OurMission({ comp }) {
+export default function Mission({ comp }) {
   return (
     <section>
-      <section className="flex flex-col items-center justify-center pt-20 pb-10 gap-y-6 bg-white">
-        <h1 className="lg:text-5xl text-7xl">
+      <section className="flex flex-col items-center justify-center pt-20 pb-10 gap-y-2 lg:gap-y-6 bg-white">
+        <h1 className="text-4xl lg:text-5xl">
           <strong>Our Mission</strong>
         </h1>
-        <p className="text-center text-5xl lg:text-3xl text-3xl mb-4 lg:px-14 px-24 py-8">
-          At Blueprint, we strive to make technology <br /> accessible for those
-          who promote public <br /> welfare and give back to our communities.
+        <p className="text-center text-xl lg:text-3xl mb-4 px-12 max-w-3xl py-8">
+          At Blueprint, we strive to make technology accessible for those who
+          promote public welfare and give back to our communities.
         </p>
       </section>
       <comp.Carousel

--- a/src/_components/About/Sponsors.jsx
+++ b/src/_components/About/Sponsors.jsx
@@ -1,22 +1,22 @@
 export default function Sponsors({ comp }) {
   return (
-    <section className="flex place-content-center items-center justify-center">
-      <div className="flex flex-col items-center p-8 max-lg:px-12 w-full max-md:px-4">
-        <h1 className="leading-10 mb-6 lg:mb-12 text-4xl lg:text-5xl">
+    <section className="flex items-center justify-center">
+      <div className="flex flex-col lg:items-center p-8 w-full">
+        <h1 className="leading-10 mb-12 text-4xl lg:text-5xl">
           <strong>Our Sponsors</strong>
         </h1>
-        <p className="text-center text-xl lg:text-2xl mb-4 lg:px-14 px-12 py-8 max-w-2xl">
+        <p className="lg:text-center text-xl lg:text-2xl mb-4 lg:px-14 pb-8 max-w-2xl">
           We are grateful to our sponsors who provide us with the resources and
           support we need at Blueprint.
         </p>
         <comp.Button
           style={
-            "px-16 py-2 rounded-xl border-2 border-black text-black font-bold w-fit lg:text-xl hover:bg-primary hover:text-white transition-all"
+            "mx-auto px-16 py-2 rounded-xl border-2 border-black text-black font-bold w-fit lg:text-xl hover:bg-primary hover:text-white transition-all"
           }
           text={"Become a sponsor"}
           redirect_url={"/partners"}
         />
-        <div className="flex flex-row py-12 gap-5 mb-16 ml-8">
+        <div className="flex flex-row py-12 gap-5 mb-16 mx-auto pl-8">
           <img
             src="../assets/logos/notion.png"
             alt="notion"

--- a/src/_components/About/Sponsors.jsx
+++ b/src/_components/About/Sponsors.jsx
@@ -1,32 +1,34 @@
-export default function Mission({ comp }) {
-  <section className="flex place-content-center items-center justify-center">
-    <div className="flex flex-col items-center p-8 max-lg:px-12 w-full max-md:px-4">
-      <h1 className="leading-10 mb-6 lg:mb-12 text-4xl lg:text-5xl">
-        <strong>Our Sponsors</strong>
-      </h1>
-      <p className="text-center text-xl lg:text-2xl mb-4 lg:px-14 px-12 py-8 max-w-2xl">
-        We are grateful to our sponsors who provide us with the resources and
-        support we need at Blueprint.
-      </p>
-      <comp.Button
-        style={
-          "px-16 py-2 rounded-xl border-2 border-black text-black font-bold w-fit lg:text-xl hover:bg-primary hover:text-white transition-all"
-        }
-        text={"Become a sponsor"}
-        redirect_url={"/partners"}
-      />
-      <div className="flex flex-row py-12 gap-5 mb-16 ml-8">
-        <img
-          src="../assets/logos/notion.png"
-          alt="notion"
-          className="object-cover h-20 max-w-none"
+export default function Sponsors({ comp }) {
+  return (
+    <section className="flex place-content-center items-center justify-center">
+      <div className="flex flex-col items-center p-8 max-lg:px-12 w-full max-md:px-4">
+        <h1 className="leading-10 mb-6 lg:mb-12 text-4xl lg:text-5xl">
+          <strong>Our Sponsors</strong>
+        </h1>
+        <p className="text-center text-xl lg:text-2xl mb-4 lg:px-14 px-12 py-8 max-w-2xl">
+          We are grateful to our sponsors who provide us with the resources and
+          support we need at Blueprint.
+        </p>
+        <comp.Button
+          style={
+            "px-16 py-2 rounded-xl border-2 border-black text-black font-bold w-fit lg:text-xl hover:bg-primary hover:text-white transition-all"
+          }
+          text={"Become a sponsor"}
+          redirect_url={"/partners"}
         />
-        <img
-          src="../assets/logos/github.png"
-          alt="github"
-          className="object-cover h-20 max-w-none"
-        />
+        <div className="flex flex-row py-12 gap-5 mb-16 ml-8">
+          <img
+            src="../assets/logos/notion.png"
+            alt="notion"
+            className="object-cover h-20 max-w-none"
+          />
+          <img
+            src="../assets/logos/github.png"
+            alt="github"
+            className="object-cover h-20 max-w-none"
+          />
+        </div>
       </div>
-    </div>
-  </section>;
+    </section>
+  );
 }

--- a/src/_components/About/Sponsors.jsx
+++ b/src/_components/About/Sponsors.jsx
@@ -1,0 +1,32 @@
+export default function Mission({ comp }) {
+  <section className="flex place-content-center items-center justify-center">
+    <div className="flex flex-col items-center p-8 max-lg:px-12 w-full max-md:px-4">
+      <h1 className="leading-10 mb-6 lg:mb-12 text-4xl lg:text-5xl">
+        <strong>Our Sponsors</strong>
+      </h1>
+      <p className="text-center text-xl lg:text-2xl mb-4 lg:px-14 px-12 py-8 max-w-2xl">
+        We are grateful to our sponsors who provide us with the resources and
+        support we need at Blueprint.
+      </p>
+      <comp.Button
+        style={
+          "px-16 py-2 rounded-xl border-2 border-black text-black font-bold w-fit lg:text-xl hover:bg-primary hover:text-white transition-all"
+        }
+        text={"Become a sponsor"}
+        redirect_url={"/partners"}
+      />
+      <div className="flex flex-row py-12 gap-5 mb-16 ml-8">
+        <img
+          src="../assets/logos/notion.png"
+          alt="notion"
+          className="object-cover h-20 max-w-none"
+        />
+        <img
+          src="../assets/logos/github.png"
+          alt="github"
+          className="object-cover h-20 max-w-none"
+        />
+      </div>
+    </div>
+  </section>;
+}

--- a/src/_components/About/Team.jsx
+++ b/src/_components/About/Team.jsx
@@ -1,8 +1,8 @@
 export default function Team({ comp, team }) {
   return (
     <section>
-      <div className="flex flex-col items-center mb-16">
-        <h1 className="text-4xl lg:text-5xl mb-8">
+      <div className="flex flex-col lg:items-center mb-16">
+        <h1 className="text-4xl lg:text-5xl mb-8 px-8">
           <strong>Our Team</strong>
         </h1>
         <div className="flex flex-wrap gap-6 my-8 px-4 lg:px-24 lg:max-w-[75rem] justify-center">

--- a/src/_components/About/Team.jsx
+++ b/src/_components/About/Team.jsx
@@ -1,0 +1,22 @@
+export default function Team({ comp, team }) {
+  return (
+    <section>
+      <div className="flex flex-col items-center mb-16">
+        <h1 className="text-4xl lg:text-5xl mb-8">
+          <strong>Our Team</strong>
+        </h1>
+        <div className="flex flex-wrap gap-6 my-8 px-4 lg:px-24 lg:max-w-[75rem] justify-center">
+          {team.map((member, index) => (
+            <comp.MemberCard
+              key={index}
+              name={member.name}
+              role={member.role}
+              image_url={member.image_url}
+              linkedin={member.linkedin}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/_components/About/Values.jsx
+++ b/src/_components/About/Values.jsx
@@ -1,7 +1,7 @@
 export default function Values({ comp, values }) {
   return (
     <section className="flex place-content-center" id="info">
-      <div className="flex flex-col items-center py-20 px-8 lg:px-40">
+      <div className="flex flex-col lg:items-center py-20 px-8 lg:px-40">
         <h1 className="mb-12 text-4xl lg:text-5xl">
           <strong>Our Values</strong>
         </h1>

--- a/src/_components/About/Values.jsx
+++ b/src/_components/About/Values.jsx
@@ -1,0 +1,16 @@
+export default function Values({ comp, values }) {
+  return (
+    <section className="flex place-content-center" id="info">
+      <div className="flex flex-col items-center py-20 px-8 lg:px-40">
+        <h1 className="mb-12 text-4xl lg:text-5xl">
+          <strong>Our Values</strong>
+        </h1>
+        <div className="flex flex-col sm:flex-row lg:p-10 gap-14">
+          {values.map((value, index) => (
+            <comp.ValueCard key={index} value={value} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/_components/ForNPOs/ProjectTimeline.jsx
+++ b/src/_components/ForNPOs/ProjectTimeline.jsx
@@ -11,10 +11,10 @@ export default function ProjectTimeline({ projectTimeline }) {
           Our Project Timeline
         </h1>
       </div>
-      <div className="grid lg:grid-cols-3">
+      <div className="grid lg:grid-cols-3 lg:gap-x-24">
         {projectTimeline.map((phase, index) => {
           return (
-            <div key={index} className="py-8 lg:pr-12">
+            <div key={index} className="py-8">
               <h2 className="pb-4 text-2xl lg:text-3xl text-primary font-bold">
                 {phase.title}
               </h2>

--- a/src/_components/ForStudents/Hero.jsx
+++ b/src/_components/ForStudents/Hero.jsx
@@ -25,7 +25,7 @@ export default function Hero({ comp }) {
         <img
           src="../../assets/events/students_hero.jpg"
           alt="A photo of student Blueprint members"
-          className="rounded-[20px] w-full h-auto object-cover"
+          className="rounded-2xl w-full h-auto object-cover"
         />
       </div>
     </section>

--- a/src/_components/MemberCard.jsx
+++ b/src/_components/MemberCard.jsx
@@ -2,19 +2,19 @@ import React from "react";
 
 export default function MemberCard({ name, role, image_url, linkedin }) {
   return (
-    <figure className="flex flex-col items-center p-4">
+    <figure className="flex flex-col items-center lg:p-4">
       <img
-        className="rounded-lg mb-4 object-cover object-center lg:w-32 lg:h-32 w-80 h-80"
+        className="rounded-lg mb-4 object-cover object-center lg:w-32 lg:h-32 w-40 h-40"
         src={image_url}
         alt="member image"
       />
       <figcaption className="text-center">
-        <div className="font-semibold lg:text-base text-3xl">{name}</div>
-        <div className="lg:text-base text-3xl">{role}</div>
+        <div className="font-semibold lg:text-base text-xl">{name}</div>
+        <div className="lg:text-base text-xl">{role}</div>
       </figcaption>
       <a href={linkedin}>
         <img
-          className="mb-4 object-cover object-center lg:w-8 lg:h-8 w-12 h-12"
+          className="mb-4 mt-1 object-cover object-center w-8 h-8"
           src="../assets/logos/linkedin.png"
           alt="LinkedIn Logo"
         />

--- a/src/_components/ValueCard.jsx
+++ b/src/_components/ValueCard.jsx
@@ -4,10 +4,10 @@ export default function ValueCard({ value }) {
   return (
     <article className="w-full flex gap-5 flex-col text-center text-pretty lg:w-1/2 sm:w-3/4">
       <img src={value.icon} alt={value.header} className="w-1/8 mx-auto" />
-      <h1 className="font-semibold uppercase md:text-3xl text-4xl">
+      <h1 className="font-semibold uppercase text-2xl lg:text-3xl">
         {value.header}
       </h1>
-      <p className="md:leading-7 md:text-[25px] text-sm">{value.text}</p>
+      <p className="lg:leading-7 lg:text-2xl text-xl">{value.text}</p>
     </article>
   );
 }

--- a/src/_components/ValueCard.jsx
+++ b/src/_components/ValueCard.jsx
@@ -2,10 +2,19 @@ import React from "react";
 
 export default function ValueCard({ value }) {
   return (
-    <article className="w-full flex gap-5 flex-col text-center text-pretty lg:w-1/2 sm:w-3/4">
-      <img src={value.icon} alt={value.header} className="w-1/8 mx-auto" />
-      <h1 className="font-semibold uppercase text-2xl lg:text-3xl">
+    <article className="w-full flex gap-5 flex-col lg:text-center text-pretty lg:w-1/2 sm:w-3/4">
+      <img
+        src={value.icon}
+        alt={value.header}
+        className="hidden lg:block w-1/8 mx-auto"
+      />
+      <h1 className="font-semibold uppercase text-2xl lg:text-3xl flex items-center lg:justify-center">
         {value.header}
+        <img
+          src={value.icon}
+          alt={value.header}
+          className="block lg:hidden h-10 ml-2"
+        />
       </h1>
       <p className="lg:leading-7 lg:text-2xl text-xl">{value.text}</p>
     </article>

--- a/src/_includes/_layouts/About.jsx
+++ b/src/_includes/_layouts/About.jsx
@@ -15,67 +15,10 @@ export default ({ comp, values, team }) => (
       <div>
         <comp.Navbar />
         <comp.About.Hero />
-        <comp.About.OurMission />
-        <section className="flex place-content-center" id="info">
-          <div className="flex flex-col items-center py-20 max-lg:px-12max-md:px-4">
-            <h1 className="leading-10 md:text-[40px] mb-14 text-6xl">
-              <strong>Our Values</strong>
-            </h1>
-            <div className="flex flex-col sm:flex-row p-20 gap-10">
-              {values.map((value, index) => (
-                <comp.ValueCard key={index} value={value} />
-              ))}
-            </div>
-          </div>
-        </section>
-        <section className="flex place-content-center items-center justify-center">
-          <div className="flex flex-col items-center p-8 max-lg:px-12 w-full max-md:px-4">
-            <h1 className="leading-10 md:text-[40px] mb-14 text-6xl">
-              <strong>Our Sponsors</strong>
-            </h1>
-            <p className="text-center text-2xl lg:text-2xl text-2xl mb-4 lg:px-14 px-12 py-8">
-              We are grateful to our sponsors who provide us with <br /> the
-              resources and support we need at Blueprint.
-            </p>
-            <comp.Button
-              style={
-                "lg:px-6 px-12 lg:py-4 py-8 lg:rounded-lg rounded-3xl border-2 border-black mt-8 text-black font-bold w-fit lg:text-base text-4xl hover:bg-primary hover:text-white"
-              }
-              text={"Become a sponsor"}
-              redirect_url={"/partners"}
-            />
-            <div className="flex flex-row py-12 gap-5 ml-8">
-              <img
-                src="../assets/logos/notion.png"
-                alt="notion"
-                className="object-cover h-20 max-w-none "
-              />
-              <img
-                src="../assets/logos/github.png"
-                alt="github"
-                className="object-cover h-20 max-w-none "
-              />
-            </div>
-          </div>
-        </section>
-        <section>
-          <div className="flex flex-col items-center">
-            <h1 className="lg:text-4xl text-6xl mb-8">
-              <strong>Our Team</strong>
-            </h1>
-            <div className="flex flex-wrap gap-4 my-8 lg:px-24 lg:max-w-[75rem] px-24 justify-center">
-              {team.map((member, index) => (
-                <comp.MemberCard
-                  key={index}
-                  name={member.name}
-                  role={member.role}
-                  image_url={member.image_url}
-                  linkedin={member.linkedin}
-                />
-              ))}
-            </div>
-          </div>
-        </section>
+        <comp.About.Mission />
+        <comp.About.Values values={values} />
+        <comp.About.Sponsors />
+        <comp.About.Team team={team} />
         <comp.Footer />
       </div>
     </body>


### PR DESCRIPTION
# Description 

This is a mobile responsiveness PR for the About page. What was done:
- fixed issue with NPOs page where text had right padding so the timeline info was not centered
- refactored each section into its own component under the same page's folder
- altered text size and classes to be consistent and align with other mobile view pages

# Demo

<img src="https://github.com/user-attachments/assets/a8b95bd1-25c5-4b97-b369-46c7813c7732" alt="drawing" width="300"/>

---

Related to #301 