### PR TITLE
Projects Page Responsiveness

### DIFF
--- a/src/_components/About/Hero.jsx
+++ b/src/_components/About/Hero.jsx
@@ -7,7 +7,7 @@ export default function Hero({ comp }) {
         <h1 className="font-bold text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16">
           About Us
         </h1>
-        <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14 text-left">
+        <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14">
           We are the Stevens Institute of Technology chapter of Blueprint that
           develops pro-bono software for non-profit organizations and promotes
           tech for social good.

--- a/src/_components/About/Hero.jsx
+++ b/src/_components/About/Hero.jsx
@@ -12,7 +12,7 @@ export default function Hero({ comp }) {
           develops pro-bono software for non-profit organizations and promotes
           tech for social good.
         </p>
-        <div className="flex flex-col md:flex-row md:justify-center lg:justify-start space-y-4 md:space-y-0 md:space-x-6">
+        <div className="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-6">
           <comp.HeroButton
             text="Follow our Instagram"
             redirect_url="https://instagram.com/stevensblueprint"

--- a/src/_components/FilterButtons.jsx
+++ b/src/_components/FilterButtons.jsx
@@ -1,30 +1,37 @@
 import React from "https://esm.sh/react@19.0.0";
 
+const years = ["2025", "2024", "2023"];
+const statuses = ["In Progress", "Completed"];
+
 export default function FilterButtons() {
   return (
-    <div className="flex justify-center gap-4">
+    <div className="flex gap-4">
       <form method="GET" className="flex gap-4">
         <select
           name="year"
-          className="bg-blue-500 text-white text-lg px-6 py-3 pr-10 rounded cursor-pointer"
+          className="bg-primary text-white border-r-8 border-primary lg:text-lg px-4 lg:px-6 py-3 rounded cursor-pointer"
+          aria-label="Filter by year"
         >
-          <option value="" className="text-center">
-            Filter by year
-          </option>
-          <option value="2025">2025</option>
-          <option value="2024">2024</option>
-          <option value="2023">2023</option>
+          <option value="">Filter by year</option>
+          {years.map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
         </select>
 
         <select
           name="sort"
-          className="bg-blue-500 text-white text-lg px-6 py-3 pr-10 rounded cursor-pointer"
+          className="bg-primary text-white border-r-8 border-primary lg:text-lg px-2 lg:px-6 py-3 rounded cursor-pointer"
         >
           <option value="" className="text-center">
             Sort
           </option>
-          <option value="In Progress">In Progress</option>
-          <option value="Completed">Completed</option>
+          {statuses.map((status) => (
+            <option key={status} value={status}>
+              {status}
+            </option>
+          ))}
         </select>
 
         <button type="submit" className="hidden">

--- a/src/_components/ProjectCard.jsx
+++ b/src/_components/ProjectCard.jsx
@@ -10,7 +10,7 @@ export default function ProjectCard({
 }) {
   const box_styling = status === "Completed" ? "bg-primary" : "bg-maroon";
   return (
-    <figure className="flex-col flex shadow-lg hover:shadow-2xl transition-shadow w-full rounded-lg lg:p-10 p-8">
+    <figure className="flex-col flex shadow-2xl lg:shadow-lg lg:hover:shadow-2xl lg:transition-shadow w-full rounded-lg lg:p-10 p-8">
       <div className="flex flex-row justify-start items-center w-full">
         <p
           className={`${box_styling} px-2 py-1 max-w-max my-3 rounded-md text-white lg:text-lg text-lg font-medium`}

--- a/src/_components/Projects/Gallery.jsx
+++ b/src/_components/Projects/Gallery.jsx
@@ -1,0 +1,24 @@
+export default function Gallery({ comp, projects }) {
+  return (
+    <div className="container mx-auto px-8 py-10 mb-16">
+      <section className="flex justify-center mb-8 lg:mb-20">
+        <comp.FilterButtons />
+      </section>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-7xl mx-auto">
+        {projects.map((project, idx) => (
+          <div key={idx} className="w-full flex justify-center">
+            <comp.ProjectCard
+              name_organization={project.name_organization}
+              image_url={project.image_url}
+              status={project.status}
+              description={project.description}
+              redirect_url={project.redirect_url}
+              project_tag={project.project_tag}
+              year={project.year}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/_components/Projects/Hero.jsx
+++ b/src/_components/Projects/Hero.jsx
@@ -12,7 +12,7 @@ export default function Hero({ comp }) {
           accessiblity. We believe in the importance of building technology that
           connects and gives back to the community.
         </p>
-        <div className="flex flex-col md:flex-row md:justify-center lg:justify-start space-y-4 md:space-y-0 md:space-x-6">
+        <div className="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-6">
           <comp.HeroButton
             redirect_url={"https://github.com/stevensblueprint/"}
             text={"View Our Github"}

--- a/src/_components/Projects/Hero.jsx
+++ b/src/_components/Projects/Hero.jsx
@@ -2,12 +2,12 @@ import React from "https://esm.sh/react";
 
 export default function Hero({ comp }) {
   return (
-    <section className="flex flex-col min-h-[700px] lg:flex-row lg:items-center bg-primary text-white">
-      <div className="px-6 md:px-12 lg:px-32 py-8 md:py-16 lg:py-0 w-full">
-        <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl tracking-wide mb-4 md:mb-6 lg:mb-16 text-center lg:text-left">
+    <section className="grow flex flex-col min-h-[700px] lg:flex-row lg:items-center overflow-hidden bg-primary text-white px-6 md:px-12 lg:px-32">
+      <div className="py-8 md:py-16 lg:py-0 w-full lg:w-1/2 lg:pr-20">
+        <h1 className="font-bold text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16">
           Projects
         </h1>
-        <p className="lg:text-2xl mb-12 lg:px-0 px-10 text-center lg:text-left">
+        <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14">
           All of our work is open source to maintain transparency and
           accessiblity. We believe in the importance of building technology that
           connects and gives back to the community.
@@ -20,7 +20,7 @@ export default function Hero({ comp }) {
           <comp.HeroButton redirect_url={"/students"} text={"Work With Us"} />
         </div>
       </div>
-      <div className="flex px-6 md:px-12 grow w-full justify-center pb-12">
+      <div className="flex grow w-full lg:w-1/2 justify-center pb-8 md:pb-12">
         <img
           src="/assets/clip_art/ProjectHeroIcon.svg"
           alt="projects-banner-image"

--- a/src/_components/Projects/Interested.jsx
+++ b/src/_components/Projects/Interested.jsx
@@ -1,0 +1,17 @@
+export default function Interested() {
+  return (
+    <section className="flex flex-col lg:items-center justify-center pt-20 lg:pb-10 gap-y-2 lg:gap-y-6 bg-white px-8">
+      <h1 className="text-4xl lg:text-5xl">
+        <strong>Project Gallery</strong>
+      </h1>
+      <p className="lg:text-center text-xl lg:text-3xl lg:mb-4 max-w-4xl py-8">
+        Interested in collaborating with other peers at Stevens on a project?{" "}
+        <br /> Check out our{" "}
+        <a href="/students" className="underline">
+          student opportunities
+        </a>
+        !
+      </p>
+    </section>
+  );
+}

--- a/src/_includes/_layouts/Projects.jsx
+++ b/src/_includes/_layouts/Projects.jsx
@@ -6,16 +6,20 @@ export default ({ comp, projects }) => (
       <meta property="og:url" content="https://sitblueprint.com/projects/" />
       <link rel="stylesheet" href="/styles.css" />
       <title>Stevens Blueprint</title>
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0"
+      ></meta>
     </head>
     <body>
       <div>
         <comp.Navbar />
         <comp.Projects.Hero />
-        <section className="flex flex-col items-center justify-center pt-20 pb-10 gap-y-6 bg-white">
-          <h1 className="lg:text-5xl text-7xl">
+        <section className="flex flex-col lg:items-center justify-center pt-20 lg:pb-10 gap-y-2 lg:gap-y-6 bg-white px-8">
+          <h1 className="text-4xl lg:text-5xl">
             <strong>Project Gallery</strong>
           </h1>
-          <p className="text-center text-2xl lg:text-2xl text-2xl mb-4 lg:px-14 px-24">
+          <p className="lg:text-center text-xl lg:text-3xl lg:mb-4 max-w-4xl py-8">
             Interested in collaborating with other peers at Stevens on a
             project? <br /> Check out our{" "}
             <a href="/students" className="underline">
@@ -24,11 +28,11 @@ export default ({ comp, projects }) => (
             !
           </p>
         </section>
-        <div className="container mx-auto px-4 py-10">
-          <section className="flex justify-center mb-20">
+        <div className="container mx-auto px-8 py-10 mb-16">
+          <section className="flex justify-center mb-8 lg:mb-20">
             <comp.FilterButtons />
           </section>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-7xl mx-auto px-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-7xl mx-auto">
             {projects.map((project, idx) => (
               <div key={idx} className="w-full flex justify-center">
                 <comp.ProjectCard

--- a/src/_includes/_layouts/Projects.jsx
+++ b/src/_includes/_layouts/Projects.jsx
@@ -15,39 +15,8 @@ export default ({ comp, projects }) => (
       <div>
         <comp.Navbar />
         <comp.Projects.Hero />
-        <section className="flex flex-col lg:items-center justify-center pt-20 lg:pb-10 gap-y-2 lg:gap-y-6 bg-white px-8">
-          <h1 className="text-4xl lg:text-5xl">
-            <strong>Project Gallery</strong>
-          </h1>
-          <p className="lg:text-center text-xl lg:text-3xl lg:mb-4 max-w-4xl py-8">
-            Interested in collaborating with other peers at Stevens on a
-            project? <br /> Check out our{" "}
-            <a href="/students" className="underline">
-              student opportunities
-            </a>
-            !
-          </p>
-        </section>
-        <div className="container mx-auto px-8 py-10 mb-16">
-          <section className="flex justify-center mb-8 lg:mb-20">
-            <comp.FilterButtons />
-          </section>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-7xl mx-auto">
-            {projects.map((project, idx) => (
-              <div key={idx} className="w-full flex justify-center">
-                <comp.ProjectCard
-                  name_organization={project.name_organization}
-                  image_url={project.image_url}
-                  status={project.status}
-                  description={project.description}
-                  redirect_url={project.redirect_url}
-                  project_tag={project.project_tag}
-                  year={project.year}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
+        <comp.Projects.Interested />
+        <comp.Projects.Gallery projects={projects} />
         <comp.Footer />
       </div>
     </body>


### PR DESCRIPTION
# Description 

This is a mobile responsiveness PR for the Projects page. What was done:
- fixed hero section responsiveness
- refactored each section into its own component under the same page's folder
- altered text size and classes to be consistent and align with other mobile view pages
- refactored small bits of code (i.e. filter buttons)

Notes:
 - Feel free to comment on the refactored file names. Not sure if they align the best but it was the thing that came first the mind. 
 - I also defaulted the hover to 2xl on mobile since you can't hover on mobile - this is the strategy we use somewhere else where we auto use the 'hovered' styling when it's on mobile. 
 - i didn't change anything with the project cards directly just some padding. I think the way it cuts of the text is p chill as of rn. The only other thing I think we should do is make the whole card clickable rather than just the "learn more" part

# Demo

<img src="https://github.com/user-attachments/assets/95b70d80-a5dc-48e7-84e5-f6f176cda67d" alt="drawing" width="300"/>

---

Related to #302 
