### PR TITLE
fix: add GoogleAnalytics to all layouts missing GA tracking

### DIFF
--- a/src/_includes/_layouts/About.jsx
+++ b/src/_includes/_layouts/About.jsx
@@ -1,6 +1,7 @@
 export default ({ comp, values, team, alumni }) => (
   <html>
     <head>
+      <comp.GoogleAnalytics />
       <comp.OpenGraphCommon />
       <link
         rel="preload"

--- a/src/_includes/_layouts/Blog.jsx
+++ b/src/_includes/_layouts/Blog.jsx
@@ -1,6 +1,7 @@
 export default ({ comp, featured_post, posts }) => (
   <html>
     <head>
+      <comp.GoogleAnalytics />
       <comp.OpenGraphCommon />
       <meta property="og:title" content="Stevens Blueprint Blog" />
       <meta property="og:url" content="https://sitblueprint.com/blog/" />

--- a/src/_includes/_layouts/ForNPOs.jsx
+++ b/src/_includes/_layouts/ForNPOs.jsx
@@ -7,6 +7,7 @@ export default ({
 }) => (
   <html>
     <head>
+      <comp.GoogleAnalytics />
       <comp.OpenGraphCommon />
       <link rel="stylesheet" href="/styles.css" />
       <title>For Non-Profits</title>

--- a/src/_includes/_layouts/ForStudents.jsx
+++ b/src/_includes/_layouts/ForStudents.jsx
@@ -1,6 +1,7 @@
 export default ({ comp, faqs, timelineContent }) => (
   <html>
     <head>
+      <comp.GoogleAnalytics />
       <comp.OpenGraphCommon />
       <link
         rel="preload"

--- a/src/_includes/_layouts/Home.jsx
+++ b/src/_includes/_layouts/Home.jsx
@@ -2,6 +2,7 @@ export default ({ comp, title, about }) => {
   return (
     <html>
       <head>
+        <comp.GoogleAnalytics />
         <comp.OpenGraphCommon />
         <meta
           name="viewport"

--- a/src/_includes/_layouts/Projects.jsx
+++ b/src/_includes/_layouts/Projects.jsx
@@ -1,6 +1,7 @@
 export default ({ comp, projects }) => (
   <html>
     <head>
+      <comp.GoogleAnalytics />
       <comp.OpenGraphCommon />
       <meta property="og:title" content="Stevens Blueprint Projects" />
       <meta property="og:url" content="https://sitblueprint.com/projects/" />

--- a/src/_includes/_layouts/Sponsors.jsx
+++ b/src/_includes/_layouts/Sponsors.jsx
@@ -6,6 +6,7 @@ export default ({
 }) => (
   <html>
     <head>
+      <comp.GoogleAnalytics />
       <comp.OpenGraphCommon />
       <link rel="stylesheet" href="/styles.css" />
       <title>Sponsors</title>


### PR DESCRIPTION
Ensures Google Analytics is injected in Blog, Projects, Sponsors, ForNPOs, About, ForStudents, and Home layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics tracking has been enabled across all major pages to better understand usage patterns and improve the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->