### PR TITLE
fix: Adjusted Hero size and text style in About Us

### DIFF
--- a/src/_includes/_layouts/About.jsx
+++ b/src/_includes/_layouts/About.jsx
@@ -30,7 +30,7 @@ export default ({
     </head>
     <body>
       <div>
-        <section className="relative flex flex-col min-h-[600px] overflow-hidden bg-primary text-white">
+        <div className="relative overflow-hidden bg-primary text-white">
           <img
             src={hero.image.src}
             alt=""
@@ -49,11 +49,11 @@ export default ({
           <div className="relative z-20">
             <comp.Navbar transparent={true} />
           </div>
-          <div className="relative z-10 flex flex-col items-start text-left py-12 px-6 md:px-12 lg:px-32 max-w-3xl mr-auto flex-1 justify-center">
-            <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6">
+          <section className="relative z-10 flex flex-col md:min-h-[600px] items-start text-left py-8 md:py-16 lg:py-0 px-6 md:px-12 lg:px-32 pl-10 md:pl-20 lg:pl-44 max-w-3xl mr-auto justify-center">
+            <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl leading-snug md:leading-[1.3] tracking-wide mb-4 md:mb-6 lg:mb-16">
               {hero.title}
             </h1>
-            <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-8 md:mb-12">
+            <p className="text-lg md:text-xl lg:text-2xl leading-snug md:leading-[1.3] mb-6 md:mb-10 lg:mb-14">
               {hero.description}
             </p>
             <div className="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-6">
@@ -70,8 +70,8 @@ export default ({
                 />
               )}
             </div>
-          </div>
-        </section>
+          </section>
+        </div>
         <comp.About.Mission mission={mission} />
         <comp.About.Values values={values} />
         <comp.About.Sponsors sponsors={sponsors} />


### PR DESCRIPTION
## Description
Updated size of the hero content area in the `About Us` section to match the rest of the website sections. Matched the text style and position from the `Projects` section as well.

### Before:
<img width="2880" height="1632" alt="image" src="https://github.com/user-attachments/assets/de73feb9-2c3e-4106-b123-291cb7d87e95" />

### After:
<img width="2880" height="1632" alt="image" src="https://github.com/user-attachments/assets/920df264-4eb2-42fc-94f3-3a3219ddd9b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved hero section layout with enhanced responsive spacing and padding adjustments across different screen sizes.
  * Refined margins for headings and paragraphs for better visual hierarchy and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->