### PR TITLE
fix: add meta charset UTF-8 to resolve text encoding issues

### DIFF
--- a/src/_components/OpenGraphCommon.jsx
+++ b/src/_components/OpenGraphCommon.jsx
@@ -3,6 +3,7 @@ import GoogleAnalytics from "./GoogleAnalytics.jsx";
 export default function OpenGraphCommon() {
   return (
     <head>
+      <meta charset="UTF-8" />
       <GoogleAnalytics />
       <meta property="og:type" content="website" />
       <meta

--- a/src/projects.md
+++ b/src/projects.md
@@ -50,7 +50,7 @@ projects:
     redirect_url: /projects/nj-appleseed
     project_tag: Community Resources
     year: 2025
-  - name_organization: Asian American Dream"
+  - name_organization: Asian American Dream
     status: Completed
     image_url: "../assets/logos/aad_logo.webp"
     description: We automated the matching process for AAD’s KIN Mentorship Program, replacing a 48-hour manual workflow with an efficient Gale-Shapley algorithm. Our solution improves mentor-mentee pairings and includes a directory where participants can browse profiles, fostering stronger connections within the AAPI professional network.


### PR DESCRIPTION
## Description
- Browsers were defaulting to `windows-1252` encoding because no charset declaration existed in the HTML output, causing Unicode characters (curly quotes, apostrophes) to render as mojibake (e.g. `â€™` instead of `'`)
- Added `<meta charset="UTF-8" />` to `OpenGraphCommon.jsx`
-  Removed a double quote typo in `projects.md` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a formatting error in project data
  * Added character encoding declaration to ensure proper content display across browsers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->