### PR TITLE
chore: set up Buddy Bot PR notifications

### DIFF
--- a/.github/buddies.json
+++ b/.github/buddies.json
@@ -1,0 +1,3 @@
+{
+  "miguel-merlin": "IvanFarfan08"
+}

--- a/.github/workflows/assign-buddy.yml
+++ b/.github/workflows/assign-buddy.yml
@@ -1,0 +1,39 @@
+name: Assign Coding Buddy
+on:
+    pull_request:
+        types: [opened, ready_for_review]
+
+jobs:
+    assign-reviewer:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Assign Buddy
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const fs = require('fs');
+
+                      // Read and parse the config file
+                      let buddyMap = {};
+                      try {
+                        const content = fs.readFileSync('.github/buddies.json', 'utf8');
+                        buddyMap = JSON.parse(content);
+                      } catch (err) {
+                        console.log("No buddy config found or invalid JSON.");
+                        return; // Exit if file missing
+                      }
+
+                      const author = context.payload.pull_request.user.login;
+                      const buddy = buddyMap[author];
+
+                      if (buddy) {
+                        console.log(`Assigning ${buddy} as reviewer for ${author}`);
+                        await github.rest.pulls.requestReviewers({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: context.payload.pull_request.number,
+                          reviewers: [buddy]
+                        });
+                      }


### PR DESCRIPTION
## Buddy Bot Setup

This PR wires up **Buddy Bot** PR notifications for the `website` team.

### Files added

| File | Purpose |
|------|---------|
| `.github/buddy-bot.json` | Team metadata used by Buddy Bot |
| `.github/workflows/buddy-bot.yml` | Sends PR events to the Buddy Bot webhook |

### Required repository secret

Before merging, add the following secret under **Settings → Secrets and variables → Actions**:

| Secret name | Value |
|-------------|-------|
| `BUDDY_BOT_WEBHOOK_SECRET` | The `github_secret` you supplied when adding this repository to Buddy Bot |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automatic assignment of code reviewers to pull requests through GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->